### PR TITLE
add in ability to never show certain kinds of nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,18 @@ Default settings:
       "*"
     ],
     "description": "Which symbols to include at the topmost level. * includes everything."
-  }
+  },
+  "cobiSymbolOutline.neverShowNodes": {
+    "type": "array",
+    "default": [
+    ],
+    "description": "Defines which kinds of nodes should not ever be shown in outline."
+  },
 }
 ```
 
 - **expandableNodes:** Kinds of nodes that show their children.
+- **neverShowNodes:** Kinds of nodes that never get shown (filtered out).
 - **sortOrder:** Order to sort symbols in.
 - **topLevel:** Which symbols are included at the topmost scope.
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,12 @@
                     ],
                     "description": "Defines which kinds of nodes show their children."
                 },
+                "cobiSymbolOutline.neverShowNodes": {
+                    "type": "array",
+                    "default": [
+                    ],
+                    "description": "Defines which kinds of nodes should not ever be shown in outline."
+                },
                 "cobiSymbolOutline.sortOrder": {
                     "type": "array",
                     "default": [


### PR DESCRIPTION
Adds in a new option to never show certain kinds of nodes.  The same idea as top level nodes but carried all the down recursively.  The way I use outlines for example I never want to see properties or fields.